### PR TITLE
Add Only Rule, to ierate just on an array of dates.

### DIFF
--- a/lib/montrose.rb
+++ b/lib/montrose.rb
@@ -32,6 +32,7 @@ module Montrose
   autoload :Utils, "montrose/utils"
   autoload :Week, "montrose/week"
   autoload :YearDay, "montrose/year_day"
+  autoload :Only, "montrose/rule/only"
 
   extend Chainable
 

--- a/lib/montrose/options.rb
+++ b/lib/montrose/options.rb
@@ -102,6 +102,7 @@ module Montrose
     def_option :on
     def_option :except
     def_option :exclude_end
+    def_option :only
 
     def initialize(opts = {})
       defaults = {
@@ -246,6 +247,10 @@ module Montrose
       @except = map_arg(date) { |d| as_date(d) }
     end
 
+    def only=(dates)
+      @only = map_arg(dates) { |d| as_date(d) }
+    end
+
     def inspect
       "#<#{self.class} #{to_h.inspect}>"
     end
@@ -261,6 +266,7 @@ module Montrose
         time
       end
     end
+
 
     private
 

--- a/lib/montrose/rule.rb
+++ b/lib/montrose/rule.rb
@@ -20,6 +20,7 @@ module Montrose
     autoload :Total, "montrose/rule/total"
     autoload :Until, "montrose/rule/until"
     autoload :WeekOfYear, "montrose/rule/week_of_year"
+    autoload :Only, "montrose/rule/only"
 
     def self.included(base)
       base.extend ClassMethods

--- a/lib/montrose/rule/only.rb
+++ b/lib/montrose/rule/only.rb
@@ -1,0 +1,34 @@
+module Montrose
+  module Rule
+    class Only
+      include Montrose::Rule
+
+      def self.apply_options(opts)
+        opts[:only]
+      end
+
+      # Initializes rule
+      #
+      # @param [Date] dates - array of date objects
+      #
+      def initialize(dates)
+        @dates = dates
+        @max = dates.length
+        # @count = 0
+      end
+
+      def include?(time)
+        !!@dates.include?(time.to_date)
+      end
+
+      # def advance!(time)
+      #   continue?(time)
+      # end
+
+      def continue?(time)
+        # @count <= @max && @dates.max >= time.to_date
+        @dates.max >= time.to_date
+      end
+    end
+  end
+end

--- a/lib/montrose/stack.rb
+++ b/lib/montrose/stack.rb
@@ -24,7 +24,8 @@ module Montrose
         Rule::DayOfMonth,
         Rule::DayOfYear,
         Rule::WeekOfYear,
-        Rule::MonthOfYear
+        Rule::MonthOfYear,
+        Rule::Only
       ].map { |r| r.from_options(opts) }.compact
     end
 

--- a/spec/montrose/rule/only_spec.rb
+++ b/spec/montrose/rule/only_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Montrose::Rule::Only do
+  let(:dates) { [Date.today, Date.today + 5.days] }
+  let(:rule) { Montrose::Rule::Only.new(dates) }
+
+  describe "#include?" do
+    it { assert rule.include?(time_now) }
+    it { refute rule.include?(time_now + 1.days) }
+    it { assert rule.include?(time_now + 5.days) }
+    it { refute rule.include?(time_now + 10.days) }
+  end
+
+  describe "#continue?" do
+    it { refute rule.continue? dates[1]+1.day }
+  end
+end


### PR DESCRIPTION
Adds method to iterate only on certain dates. 
Must be run with correct frequency, otherwise will miss some dates. 
```ruby 
M̀ontrose.daily(only: [dates])

Montrose.r(every: :day, only: [Time.now+3.day, Time.now+4.day, 1.year.from_now, Time.now+10.day ])
=> #<Montrose::Recurrence:820 {:every=>:day, :only=>[Sun, 27 Aug 2023, Mon, 28 Aug 2023, Sat, 24 Aug 2024, Sun, 03 Sep 2023]}>

Montrose.r(every: :day, only: [Time.now+3.day, Time.now+4.day, 1.year.from_now, Time.now+10.day ]).take 4
=> [2023-08-27 14:53:12 -0300, 2023-08-28 14:53:12 -0300, 2023-09-03 14:53:12 -0300, 2024-08-24 14:53:12 -0300]

```

PS.: Not optimized, since iterate in the array. Just built to add compatibility to add just some limited date using the same API as Montrose. 